### PR TITLE
Improve recursive lock errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- Better error messages for recursive transactions.
+- Breaking change: Error by default when starting a read transaction within a write transaction.
+
 ## 0.2.1
 
 - Fix update notifications missing the first update.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ void main() async {
   // 1. Atomic persistence (all updates are either applied or rolled back).
   // 2. Improved throughput.
   await db.writeTransaction((tx) async {
-    await db.execute('INSERT INTO test_data(data) values(?)', ['Test3']);
-    await db.execute('INSERT INTO test_data(data) values(?)', ['Test4']);
+    await tx.execute('INSERT INTO test_data(data) values(?)', ['Test3']);
+    await tx.execute('INSERT INTO test_data(data) values(?)', ['Test4']);
   });
 
   await db.close();

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ query access.
  * Automatically convert query args to JSON where applicable, making JSON1 operations simple.
  * Direct SQL queries - no wrapper classes or code generation required.
 
+See this [blog post](https://www.powersync.co/blog/sqlite-optimizations-for-ultra-high-performance),
+explaining why these features are important for using SQLite.
+
 ## Installation
 
 ```sh

--- a/example/basic_example.dart
+++ b/example/basic_example.dart
@@ -29,8 +29,8 @@ void main() async {
   // 1. Atomic persistence (all updates are either applied or rolled back).
   // 2. Improved throughput.
   await db.writeTransaction((tx) async {
-    await db.execute('INSERT INTO test_data(data) values(?)', ['Test3']);
-    await db.execute('INSERT INTO test_data(data) values(?)', ['Test4']);
+    await tx.execute('INSERT INTO test_data(data) values(?)', ['Test3']);
+    await tx.execute('INSERT INTO test_data(data) values(?)', ['Test4']);
   });
 
   // Close database to release resources

--- a/lib/src/mutex.dart
+++ b/lib/src/mutex.dart
@@ -40,7 +40,7 @@ class SimpleMutex implements Mutex {
   @override
   Future<T> lock<T>(Future<T> Function() callback, {Duration? timeout}) async {
     if (Zone.current[this] != null) {
-      throw AssertionError('Recursive lock is not allowed');
+      throw LockError('Recursive lock is not allowed');
     }
     var zone = Zone.current.fork(zoneValues: {this: true});
 
@@ -132,7 +132,7 @@ class SharedMutex implements Mutex {
   @override
   Future<T> lock<T>(Future<T> Function() callback, {Duration? timeout}) async {
     if (Zone.current[this] != null) {
-      throw AssertionError('Recursive lock is not allowed');
+      throw LockError('Recursive lock is not allowed');
     }
     return runZoned(() async {
       await _acquire(timeout: timeout);
@@ -222,4 +222,15 @@ class _AcquireMessage {
 
 class _UnlockMessage {
   const _UnlockMessage();
+}
+
+class LockError extends Error {
+  final String message;
+
+  LockError(this.message);
+
+  @override
+  String toString() {
+    return 'LockError: $message';
+  }
 }

--- a/lib/src/sqlite_connection.dart
+++ b/lib/src/sqlite_connection.dart
@@ -94,13 +94,13 @@ abstract class SqliteConnection extends SqliteWriteContext {
   ///
   /// In most cases, [readTransaction] should be used instead.
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
-      {Duration? lockTimeout});
+      {Duration? lockTimeout, String? debugContext});
 
   /// Takes a global lock, without starting a transaction.
   ///
   /// In most cases, [writeTransaction] should be used instead.
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
-      {Duration? lockTimeout});
+      {Duration? lockTimeout, String? debugContext});
 
   Future<void> close();
 }

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -79,7 +79,7 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
 
   @override
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
-      {Duration? lockTimeout}) async {
+      {Duration? lockTimeout, String? debugContext}) async {
     // Private lock to synchronize this with other statements on the same connection,
     // to ensure that transactions aren't interleaved.
     return _connectionMutex.lock(() async {
@@ -94,7 +94,7 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
 
   @override
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
-      {Duration? lockTimeout}) async {
+      {Duration? lockTimeout, String? debugContext}) async {
     final stopWatch = lockTimeout == null ? null : (Stopwatch()..start());
     // Private lock to synchronize this with other statements on the same connection,
     // to ensure that transactions aren't interleaved.

--- a/lib/src/sqlite_database.dart
+++ b/lib/src/sqlite_database.dart
@@ -209,13 +209,15 @@ class SqliteDatabase with SqliteQueries implements SqliteConnection {
 
   @override
   Future<T> readLock<T>(Future<T> Function(SqliteReadContext tx) callback,
-      {Duration? lockTimeout}) {
-    return _pool.readLock(callback, lockTimeout: lockTimeout);
+      {Duration? lockTimeout, String? debugContext}) {
+    return _pool.readLock(callback,
+        lockTimeout: lockTimeout, debugContext: debugContext);
   }
 
   @override
   Future<T> writeLock<T>(Future<T> Function(SqliteWriteContext tx) callback,
-      {Duration? lockTimeout}) {
-    return _pool.writeLock(callback, lockTimeout: lockTimeout);
+      {Duration? lockTimeout, String? debugContext}) {
+    return _pool.writeLock(callback,
+        lockTimeout: lockTimeout, debugContext: debugContext);
   }
 }

--- a/lib/src/sqlite_queries.dart
+++ b/lib/src/sqlite_queries.dart
@@ -17,7 +17,7 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
       [List<Object?> parameters = const []]) async {
     return writeLock((ctx) async {
       return ctx.execute(sql, parameters);
-    });
+    }, debugContext: 'execute()');
   }
 
   @override
@@ -25,14 +25,14 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
       [List<Object?> parameters = const []]) {
     return readLock((ctx) async {
       return ctx.getAll(sql, parameters);
-    });
+    }, debugContext: 'getAll()');
   }
 
   @override
   Future<sqlite.Row> get(String sql, [List<Object?> parameters = const []]) {
     return readLock((ctx) async {
       return ctx.get(sql, parameters);
-    });
+    }, debugContext: 'get()');
   }
 
   @override
@@ -40,7 +40,7 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
       [List<Object?> parameters = const []]) {
     return readLock((ctx) async {
       return ctx.getOptional(sql, parameters);
-    });
+    }, debugContext: 'getOptional()');
   }
 
   @override
@@ -103,7 +103,7 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
       {Duration? lockTimeout}) async {
     return readLock((ctx) async {
       return await internalReadTransaction(ctx, callback);
-    }, lockTimeout: lockTimeout);
+    }, lockTimeout: lockTimeout, debugContext: 'readTransaction()');
   }
 
   @override
@@ -112,7 +112,7 @@ mixin SqliteQueries implements SqliteWriteContext, SqliteConnection {
       {Duration? lockTimeout}) async {
     return writeLock((ctx) async {
       return await internalWriteTransaction(ctx, callback);
-    }, lockTimeout: lockTimeout);
+    }, lockTimeout: lockTimeout, debugContext: 'writeTransaction()');
   }
 
   /// See [SqliteReadContext.computeWithDatabase].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.2.1
+version: 0.3.0
 repository: https://github.com/journeyapps/sqlite_async.dart
 environment:
   sdk: '>=2.19.1 <3.0.0'

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -175,6 +175,7 @@ void main() {
       // Note: In highly concurrent cases, it could exhaust the connection pool and cause a deadlock.
 
       await db.writeTransaction((tx) async {
+        // Use the parent zone to avoid the "recursive lock" error.
         await zone.fork().run(() async {
           await db.getAll('SELECT * FROM test_data');
         });
@@ -192,7 +193,7 @@ void main() {
         });
       });
 
-      // This would deadlock, since it shares a global write lock.
+      // Note: This would deadlock, since it shares a global write lock.
       // await db.writeTransaction((tx) async {
       //   await zone.fork().run(() async {
       //     await db.execute('SELECT * FROM test_data');

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
 import 'dart:math';
 
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+import 'package:sqlite_async/mutex.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:test/test.dart';
-import 'package:sqlite3/sqlite3.dart' as sqlite;
+
 import 'util.dart';
 
 void main() {
@@ -108,18 +111,22 @@ void main() {
         await expectLater(() async {
           await db.execute(
               'INSERT INTO test_data(description) VALUES(?)', ['test']);
-        }, throwsA((e) => e is AssertionError));
+        }, throwsA((e) => e is LockError && e.message.contains('tx.execute')));
       });
     });
 
-    test('does allow read-only db calls within transaction callback', () async {
+    test('should not allow read-only db calls within transaction callback',
+        () async {
       final db = await setupDatabase(path: path);
       await createTables(db);
 
       await db.writeTransaction((tx) async {
-        // This uses a different connection, so it's fine.
-        // Perhaps we should warn on this, since it's likely unintentional?
-        await db.getAll('SELECT * FROM test_data');
+        // This uses a different connection, so it _could_ work.
+        // But it's likely unintentional and could cause weird bugs, so we don't
+        // allow it by default.
+        await expectLater(() async {
+          await db.getAll('SELECT * FROM test_data');
+        }, throwsA((e) => e is LockError && e.message.contains('tx.getAll')));
       });
 
       await db.readTransaction((tx) async {
@@ -129,24 +136,68 @@ void main() {
         // opens another connection, but doesn't use it.
         await expectLater(() async {
           await db.getAll('SELECT * FROM test_data');
-        }, throwsA((e) => e is AssertionError));
+        }, throwsA((e) => e is LockError && e.message.contains('tx.getAll')));
       });
     });
 
-    test('does allow read-only db calls within lock callback', () async {
+    test('should not allow read-only db calls within lock callback', () async {
       final db = await setupDatabase(path: path);
       await createTables(db);
       // Locks - should behave the same as transactions above
 
       await db.writeLock((tx) async {
-        await db.getAll('SELECT * FROM test_data');
+        await expectLater(() async {
+          await db.getOptional('SELECT * FROM test_data');
+        },
+            throwsA(
+                (e) => e is LockError && e.message.contains('tx.getOptional')));
       });
 
       await db.readLock((tx) async {
         await expectLater(() async {
-          await db.getAll('SELECT * FROM test_data');
-        }, throwsA((e) => e is AssertionError));
+          await db.getOptional('SELECT * FROM test_data');
+        },
+            throwsA(
+                (e) => e is LockError && e.message.contains('tx.getOptional')));
       });
+    });
+
+    test(
+        'should allow read-only db calls within transaction callback in separate zone',
+        () async {
+      final db = await setupDatabase(path: path);
+      await createTables(db);
+
+      // Get a reference to the parent zone (outside the transaction).
+      final zone = Zone.current;
+
+      // Each of these are fine, since it could use a separate connection.
+      // Note: In highly concurrent cases, it could exhaust the connection pool and cause a deadlock.
+
+      await db.writeTransaction((tx) async {
+        await zone.fork().run(() async {
+          await db.getAll('SELECT * FROM test_data');
+        });
+      });
+
+      await db.readTransaction((tx) async {
+        await zone.fork().run(() async {
+          await db.getAll('SELECT * FROM test_data');
+        });
+      });
+
+      await db.readTransaction((tx) async {
+        await zone.fork().run(() async {
+          await db.execute('SELECT * FROM test_data');
+        });
+      });
+
+      // This would deadlock, since it shares a global write lock.
+      // await db.writeTransaction((tx) async {
+      //   await zone.fork().run(() async {
+      //     await db.execute('SELECT * FROM test_data');
+      //   });
+      // });
     });
 
     test('should allow PRAMGAs', () async {


### PR DESCRIPTION
Fixes #2.

Example code triggering the error:

```dart
await db.writeTransaction((tx) async {
  await db.execute('SELECT * FROM test_data');
});
```

Before:
```
AssertionError: Recursive lock is not allowed
```

After:
```
LockError: Recursive lock is not allowed. Use `tx.execute()` instead of `db.execute()`.
```

Additionally, this now blocks recursive read transactions within write transactions, and vice versa (**breaking change**). While these would use separate connections and thus could, it is likely unintentional and could lead to unexpected bugs.

In cases where it is really desired to start a new transaction within an existing transaction callback, use a separate zone. This is considered an advanced use case, and the developer will need to take care to avoid deadlocks.

```dart
// Get a reference to the parent zone (outside the transaction).
final zone = Zone.current;

await db.writeTransaction((tx) async {
  // Use the parent zone to avoid the "recursive lock" error.
  await zone.fork().run(() async {
    await db.getAll('SELECT * FROM test_data');
  });
});
```

Note that in some cases this could cause a deadlock if many transactions are started like this concurrently, exhausting the connection pool. In the specific example above, since only a single write lock can be active at a time, that won't happen.