### PR TITLE
Improved error handling and performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+- Ensure database connections are cleaned up on unhandled Isolate errors.
+- Minor performance improvements.
+
 ## 0.3.0
 
 - Better error messages for recursive transactions.

--- a/example/custom_functions_example.dart
+++ b/example/custom_functions_example.dart
@@ -1,9 +1,7 @@
-import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate';
 
 import 'package:sqlite_async/sqlite_async.dart';
-import 'package:sqlite3/open.dart' as sqlite_open;
 import 'package:sqlite3/sqlite3.dart' as sqlite;
 
 /// Since the functions need to be created on every SQLite connection,

--- a/example/json_example.dart
+++ b/example/json_example.dart
@@ -63,6 +63,7 @@ RETURNING id''', [users]);
   var ids = idRows.map((row) => row['id']).toList();
 
   // Alternatively, using json1 functions directly.
+  // ignore: unused_local_variable
   var idRows2 = await db.execute('''
 INSERT INTO users(name, email)
 SELECT e.value ->> 'name', e.value ->> 'email' FROM json_each(?) e

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -58,6 +58,9 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
       var completer = Completer<T>();
 
       var futures = _readConnections.sublist(0).map((connection) async {
+        if (connection.closed) {
+          _readConnections.remove(connection);
+        }
         try {
           return await connection.readLock((ctx) async {
             if (haveLock) {
@@ -106,6 +109,9 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
       {Duration? lockTimeout, String? debugContext}) {
     if (closed) {
       throw AssertionError('Closed');
+    }
+    if (_writeConnection?.closed == true) {
+      _writeConnection = null;
     }
     _writeConnection ??= SqliteConnectionImpl(
         upstreamPort: _upstreamPort,

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -26,6 +26,7 @@ class SqliteConnectionPool with SqliteQueries implements SqliteConnection {
 
   final Mutex mutex;
 
+  @override
   bool closed = false;
 
   /// Open a new connection pool.

--- a/lib/src/sqlite_connection.dart
+++ b/lib/src/sqlite_connection.dart
@@ -103,4 +103,7 @@ abstract class SqliteConnection extends SqliteWriteContext {
       {Duration? lockTimeout, String? debugContext});
 
   Future<void> close();
+
+  /// Returns true if the connection is closed
+  bool get closed;
 }

--- a/lib/src/sqlite_connection_impl.dart
+++ b/lib/src/sqlite_connection_impl.dart
@@ -44,6 +44,7 @@ class SqliteConnectionImpl with SqliteQueries implements SqliteConnection {
     await _isolateClient.ready;
   }
 
+  @override
   bool get closed {
     return _isolateClient.closed;
   }

--- a/lib/src/sqlite_database.dart
+++ b/lib/src/sqlite_database.dart
@@ -104,6 +104,7 @@ class SqliteDatabase with SqliteQueries implements SqliteConnection {
     await _initialized;
   }
 
+  @override
   bool get closed {
     return _pool.closed;
   }

--- a/lib/src/sqlite_database.dart
+++ b/lib/src/sqlite_database.dart
@@ -104,6 +104,10 @@ class SqliteDatabase with SqliteQueries implements SqliteConnection {
     await _initialized;
   }
 
+  bool get closed {
+    return _pool.closed;
+  }
+
   void _listenForEvents() {
     UpdateNotification? updates;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/journeyapps/sqlite_async.dart
 environment:
   sdk: '>=2.19.1 <3.0.0'

--- a/scripts/benchmark.dart
+++ b/scripts/benchmark.dart
@@ -60,13 +60,13 @@ List<SqliteBenchmark> benchmarks = [
   }, maxBatchSize: 10000, enabled: true),
   SqliteBenchmark('Write lock',
       (SqliteDatabase db, List<List<String>> parameters) async {
-    for (var params in parameters) {
+    for (var _ in parameters) {
       await db.writeLock((tx) async {});
     }
   }, maxBatchSize: 5000, enabled: false),
   SqliteBenchmark('Read lock',
       (SqliteDatabase db, List<List<String>> parameters) async {
-    for (var params in parameters) {
+    for (var _ in parameters) {
       await db.readLock((tx) async {});
     }
   }, maxBatchSize: 5000, enabled: false),


### PR DESCRIPTION
When an uncaught error is thrown in a database Isolate, the Isolate effectively crashes. This change ensures that the database connection is properly closed in that case. When using a connection pool (the default), the connection pool will automatically re-open the connection.

Additionally, this includes some minor performance improvements for cross-isolate communication, which has an effect when many individual statements are used.
