### PR TITLE
Tests for Dart 3.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,13 +30,20 @@ jobs:
     strategy:
       matrix:
         include:
+          - sqlite_version: "3420000"
+            sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3420000.tar.gz"
+            dart_sdk: 3.0.6
           - sqlite_version: "3410100"
             sqlite_url: "https://www.sqlite.org/2023/sqlite-autoconf-3410100.tar.gz"
+            dart_sdk: 2.19.1
           - sqlite_version: "3380000"
             sqlite_url: "https://www.sqlite.org/2022/sqlite-autoconf-3380000.tar.gz"
+            dart_sdk: 2.19.1
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.dart_sdk }}
 
       - name: Install dependencies
         run: dart pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0
+
+- No code changes.
+- Updated dependencies to support sqlite3 2.x.
+
 ## 0.4.0
 
 - Ensure database connections are cleaned up on unhandled Isolate errors.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/journeyapps/sqlite_async.dart
 environment:
   sdk: '>=2.19.1 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,10 @@ description: High-performance asynchronous interface for SQLite on Dart and Flut
 version: 0.4.0
 repository: https://github.com/journeyapps/sqlite_async.dart
 environment:
-  sdk: '>=2.19.1 <3.0.0'
+  sdk: '>=2.19.1 <4.0.0'
 
 dependencies:
-  sqlite3: ^1.10.1
+  sqlite3: '>=1.10.1 <3.0.0'
   async: ^2.10.0
   collection: ^1.17.0
 

--- a/test/json1_test.dart
+++ b/test/json1_test.dart
@@ -20,7 +20,7 @@ class TestUser {
 }
 
 void main() {
-  group('Basic Tests', () {
+  group('json1 Tests', () {
     late String path;
 
     setUp(() async {


### PR DESCRIPTION
This library is already compatible, but this adds explicit tests for Dart 2.19.1 and 3.0.6.

Additionally, this relaxes the dependency specification to include sqlite3 2.x.
