### PR TITLE
Fix closing of SharedMutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+- Fix releasing of locks when closing `SharedMutex``.
+
 ## 0.5.1
 
 - Fix `watch` when called with query parameters.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite_async
 description: High-performance asynchronous interface for SQLite on Dart and Flutter.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/journeyapps/sqlite_async.dart
 environment:
   sdk: '>=2.19.1 <4.0.0'

--- a/test/mutex_test.dart
+++ b/test/mutex_test.dart
@@ -1,0 +1,47 @@
+import 'dart:isolate';
+
+import 'package:sqlite_async/mutex.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Mutex Tests', () {
+    test('Closing', () async {
+      // Test that locks are properly released when calling SharedMutex.close()
+      // in in Isolate.
+      // A timeout in this test indicates a likely error.
+      for (var i = 0; i < 50; i++) {
+        final mutex = SimpleMutex();
+        final serialized = mutex.shared;
+
+        final result = await Isolate.run(() async {
+          return _lockInIsolate(serialized);
+        });
+
+        await mutex.lock(() async {});
+
+        expect(result, equals(5));
+      }
+    });
+  }, timeout: const Timeout(Duration(milliseconds: 5000)));
+}
+
+Future<Object> _lockInIsolate(
+  SerializedMutex smutex,
+) async {
+  final mutex = smutex.open();
+  // Start a "thread" that repeatedly takes a lock
+  _infiniteLock(mutex).ignore();
+  await Future.delayed(const Duration(milliseconds: 10));
+  // Then close the mutex while the above loop is running.
+  await mutex.close();
+
+  return 5;
+}
+
+Future<void> _infiniteLock(SharedMutex mutex) async {
+  while (true) {
+    await mutex.lock(() async {
+      await Future.delayed(const Duration(milliseconds: 1));
+    });
+  }
+}


### PR DESCRIPTION
If `SharedMutex.close()` was called while existing locks were open, it could prevent those locks from ever being released. This fixes it.

There aren't any known cases of this with default usage of this library, but it could happen when using Mutex/SharedMutex directly.